### PR TITLE
Fix error with MassiveJs and Webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2989,6 +2989,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
+    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -4264,6 +4273,16 @@
         "is-number": "^7.0.0"
       }
     },
+    "transfer-webpack-plugin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/transfer-webpack-plugin/-/transfer-webpack-plugin-0.1.4.tgz",
+      "integrity": "sha1-a1re3FjLqondy5606Q429nZV7XY=",
+      "dev": true,
+      "requires": {
+        "node-dir": "^0.1.6",
+        "vow": "^0.4.9"
+      }
+    },
     "ts-loader": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.0.tgz",
@@ -4449,6 +4468,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+      "dev": true
+    },
+    "vow": {
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.20.tgz",
+      "integrity": "sha512-YYoSYXUYABqY08D/WrjcWJxJSErcILRRTQpcPyUc0SFfgIPKSUFzVt7u1HC3TXGJZM/qhsSjCLNQstxqf7asgQ==",
       "dev": true
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/node": "^12.11.1",
     "file-loader": "^4.2.0",
+    "transfer-webpack-plugin": "^0.1.4",
     "ts-loader": "^6.2.0",
     "typescript": "^3.6.4",
     "webpack": "^4.41.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
+const TransferWebpackPlugin = require('transfer-webpack-plugin');
 
 module.exports = {
   mode: 'development',
@@ -19,10 +20,16 @@ module.exports = {
   },
   plugins: [
     new webpack.IgnorePlugin(/\.\/native/, /\/pg\//),
+    // load .sql script files for massive-js
+    new TransferWebpackPlugin([{ from: 'node_modules/massive/lib/scripts', to: 'scripts' }]),
   ],
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
   },
   target: 'node',
+  // disable __dirname webpack injection
+  node: {
+    __dirname: false,
+  },
 };


### PR DESCRIPTION
**What is the issue?**

When trying to make any request to database there's an error (thrown by [pg-promise](https://github.com/vitaly-t/pg-promise)):
```
(node:6759) UnhandledPromiseRejectionWarning: TypeError: Invalid query format.
    at Database.$query (/massive-webpack-ts/dist/bundle.js:33841:17)
    at Database.<anonymous> (/massive-webpack-ts/dist/bundle.js:34040:23)
    at config.$npm.connect.pool.then.db (/massive-webpack-ts/dist/bundle.js:27061:42)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
(node:6759) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 8)
```

**Where is the actual problem?**
https://gitlab.com/dmfay/massive-js/blob/master/lib/database.js#L231

**Why is it happening?**
When Webpack builds the project it ignores `.sql` files so [massive-js](https://gitlab.com/dmfay/massive-js) is making empty request via pg-promise.

**How to fix?**
There should be a better way to handle it but for now we can use [transfer-webpack-plugin](https://github.com/dkokorev90/transfer-webpack-plugin) and disable `__dirname` Webpack injection.
The plugins transfers SQL scripts from `node_modules/massive/lib/scripts` to the folder where the `bundle.js` file is hosted.
So `massive-js` can use those files.